### PR TITLE
Fixed permissions for apache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN rm -fr /app && mkdir /app && \
 ADD wp-config.php /app/wp-config.php
 RUN chmod 644 /app/wp-config.php
 
+# Fix permissions for apache
+RUN chown -R www-data:www-data /app
+
 # Add script to create 'wordpress' DB
 ADD run.sh run.sh
 RUN chmod 755 /*.sh


### PR DESCRIPTION
I was using this as an example in a new Panamax template and my app was having trouble writing to the folder and thought this repo could benefit from it too. When I tested this I noticed WordPress could not do any updates to itself or plugins which usually means permission issues and I think it is because Apache runs with a specific user `www-data` and group `www-data` and they do not have access as the `/app` directory is owned by `root`.

![screen shot 2014-08-20 at 1 00 25 am](https://cloud.githubusercontent.com/assets/207171/3977039/92d1e450-2830-11e4-9a99-ff7da564b6bf.png)

What do you think @patocox?
